### PR TITLE
Expose Syncode Logitsprocessor through syncode api

### DIFF
--- a/notebooks/example_logits_processor.ipynb
+++ b/notebooks/example_logits_processor.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### SynCode Logits Porcessor\n",
+    "In this notebook, we will use only the SyncodeLogitsProcessor with HuggingFace model to enable grammar-guided decoding."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from syncode import SyncodeLogitsProcessor\n",
+    "from syncode import Grammar\n",
+    "from transformers import AutoModelForCausalLM, AutoTokenizer\n",
+    "\n",
+    "device = 'cuda'\n",
+    "model_name = \"microsoft/phi-2\"\n",
+    "model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.bfloat16).eval().to(device)\n",
+    "tokenizer = AutoTokenizer.from_pretrained(model_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize SynCode logits processor for the given grammar\n",
+    "\n",
+    "grammar_str = \"\"\" start: month \" \" day \n",
+    "              \n",
+    "              day: /[1-9]/ | /[1-2][0-9]/ | /3[0-1]/\n",
+    "              \n",
+    "              month: \"January\" | \"February\" | \"March\" | \"April\" | \"May\" | \"June\" | \"July\" | \"August\" | \"September\" | \"October\" | \"November\" | \"December\"\n",
+    "\"\"\"\n",
+    "date_grammar = Grammar(grammar_str)\n",
+    "syncode_logits_processor = SyncodeLogitsProcessor(grammar=date_grammar, tokenizer=tokenizer, parse_output_only=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "July 4\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompt = \"When is the US independence day?\"\n",
+    "syncode_logits_processor.reset(prompt)\n",
+    "\n",
+    "inputs = tokenizer(prompt, return_tensors='pt').input_ids.to(device)\n",
+    "\n",
+    "output = model.generate(\n",
+    "      inputs,\n",
+    "      max_length=100, \n",
+    "      num_return_sequences=1, \n",
+    "      pad_token_id=tokenizer.eos_token_id, \n",
+    "      logits_processor=[syncode_logits_processor]\n",
+    "      )\n",
+    "output_str = tokenizer.decode(output[0][len(inputs[0]):], skip_special_tokens=True)\n",
+    "print(output_str)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "codex",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/syncode/__init__.py
+++ b/syncode/__init__.py
@@ -1,1 +1,3 @@
 from syncode.infer import Syncode
+from grammar_decoder import SyncodeLogitsProcessor
+from parsers.grammars import Grammar

--- a/syncode/grammar_decoder.py
+++ b/syncode/grammar_decoder.py
@@ -10,7 +10,7 @@ from syncode.dfa_mask_store import DFAMaskStore
 from syncode.parsers.grammars import Grammar
 
 
-class GrammarDecoder(LogitsProcessor):
+class SyncodeLogitsProcessor(LogitsProcessor):
     """
     This class is used to filter the logits of the model to only allow syntactically valid tokens for Python. 
 
@@ -25,7 +25,7 @@ class GrammarDecoder(LogitsProcessor):
     def __init__(self, 
         grammar: Grammar, 
         tokenizer: PreTrainedTokenizer, 
-        logger: common.Logger, 
+        logger: common.Logger=common.EmptyLogger(), 
         use_cache=True,
         parse_output_only=False, 
         num_samples=1,
@@ -66,6 +66,7 @@ class GrammarDecoder(LogitsProcessor):
         # For profiling
         self.debug = True
         self.logger.log_time(f"Time taken for preprocessing: {time.time() - time_start:.2f}s")
+
     
     def _log_current_status(self, partial_code, r: ParseResult):
         self.logger.log_code('Partial code', partial_code)

--- a/syncode/infer.py
+++ b/syncode/infer.py
@@ -3,7 +3,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import fire
 import syncode.common as common
 from syncode.language_model import HuggingFaceModel
-from syncode.grammar_decoder import GrammarDecoder
+from syncode.grammar_decoder import SyncodeLogitsProcessor
 from typing import Optional, Literal
 from syncode.parsers.grammars import Grammar
 from syncode.dataset import Dataset
@@ -105,7 +105,7 @@ class Syncode:
         self.grammar_decoder = None
         
         if self.is_grammar_mode():
-            self.grammar_decoder = GrammarDecoder(
+            self.grammar_decoder = SyncodeLogitsProcessor(
                 self.grammar, 
                 tokenizer=tokenizer, 
                 logger=self.logger, 

--- a/syncode/language_model.py
+++ b/syncode/language_model.py
@@ -1,7 +1,7 @@
 import time
 import torch
 import syncode.common as common
-from syncode.grammar_decoder import GrammarDecoder
+from syncode.grammar_decoder import SyncodeLogitsProcessor
 from transformers import LogitsProcessorList, StoppingCriteriaList, StoppingCriteria
 from syncode.parsers.grammars import Grammar
 from syncode.utils.generation import filter_code, fix_indents
@@ -144,7 +144,7 @@ class HuggingFaceModel:
         inputs:dict, 
         gen_config:GenerationConfig, 
         gen_mode:GenerationMode, 
-        grammar_decoder:GrammarDecoder=None,
+        grammar_decoder:SyncodeLogitsProcessor=None,
         stop_criteria:StoppingCriteria=[]
         ):
         """


### PR DESCRIPTION
Exposing `SyncodeLogitsProcessor` through `syncode`. This allows users to use SynCode with any HuggingFace model simply by importing 
```
from syncode import SyncodeLogitsProcessor
```
and then providing the  `SyncodeLogitsProcessor` in the `generate` method in the HF transformer model. 

Check `notebooks/example_logits_processor.ipynb` for its use