### PR TITLE
Fix issue with `quantize` parameter

### DIFF
--- a/syncode/common.py
+++ b/syncode/common.py
@@ -31,17 +31,23 @@ def get_vocab_from_tokenizer(tokenizer):
     
     return vocab
 
-def load_model(model_name, device):
+def load_model(model_name, device, quantize):
         llama_models = ["Llama-7b", "Llama-13b", "CodeLlama-7b", "CodeLlama-7b-Python"]
         if model_name == 'test':
             model = AutoModelForCausalLM.from_pretrained('bigcode/tiny_starcoder_py').to(device)
         elif model_name == 'test-instruct':
             model = AutoModelForCausalLM.from_pretrained("rahuldshetty/tiny-starcoder-instruct")
         elif model_name not in llama_models:
-            model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.bfloat16, cache_dir=HF_CACHE, token=HF_ACCESS_TOKEN, trust_remote_code=True).eval().to(device)
+            if (quantize):
+                model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.bfloat16, cache_dir=HF_CACHE, token=HF_ACCESS_TOKEN, trust_remote_code=True).eval().to(device)
+            else:
+                model = AutoModelForCausalLM.from_pretrained(model_name, cache_dir=HF_CACHE, token=HF_ACCESS_TOKEN, trust_remote_code=True).eval().to(device)
         elif model_name in llama_models:
             model_location = "/data/share/models/hugging_face/" + model_name
-            model = LlamaForCausalLM.from_pretrained(model_location, torch_dtype=torch.bfloat16).eval().to(device)
+            if (quantize):
+                model = LlamaForCausalLM.from_pretrained(model_location, torch_dtype=torch.bfloat16).eval().to(device)
+            else:
+                model = LlamaForCausalLM.from_pretrained(model_location).eval().to(device)
         return model
 
 def load_tokenizer(model_name):

--- a/syncode/infer.py
+++ b/syncode/infer.py
@@ -94,7 +94,7 @@ class Syncode:
         self.dataset = Dataset(dataset, language=grammar, num_few_shot=num_few_shot)
 
         # Load model
-        model = common.load_model(self.model_name, device)
+        model = common.load_model(self.model_name, device, quantize)
         tokenizer = common.load_tokenizer(self.model_name)
         
         # Setup output directory


### PR DESCRIPTION
From #78, 
As @shubhamugare mentioned, the parameter `quantize` is currently not being used while loading the model [here](https://github.com/uiuc-focal-lab/syncode/blob/aab13a2eef4b57ce1e474c7c60080cb5ee14a0d2/syncode/common.py#L34). 

This fix passes the `quantize` parameter to the `load_model()` and sets `torch_dtype=torch.bfloat16` only when `quantize=True`. 