### PR TITLE
Improve precision of `grammar_strict`

### DIFF
--- a/syncode/dfa_mask_store.py
+++ b/syncode/dfa_mask_store.py
@@ -453,6 +453,13 @@ class DFAMaskStore:
                                 overapprox_token_ids |= self._lookup_table.complete_case_lookup(dfa_state)
                             elif len(accept_sequence) == 2:
                                 overapprox_token_ids |= self._lookup_next_tokens_for_dfa_state(dfa_state, accept_sequence[1])
+                            elif len(accept_sequence) == 3:
+                                # This is useful in under-approximating `grammar_strict` mode as they help improve the precision of SynCode
+                                if self._mode == 'grammar_strict':
+                                    # If the DFA state is a final state we can jump to the start of next terminal
+                                    if self._dfas.is_final(dfa_state): 
+                                        ignore_init_state = self._dfas.initial(accept_sequence[1])
+                                        overapprox_token_ids |= self._lookup_next_tokens_for_dfa_state(ignore_init_state, accept_sequence[2])
                             else:
                                 raise ValueError(f"Invalid accept sequence: {accept_sequence}")
         return overapprox_token_ids

--- a/syncode/parse_result.py
+++ b/syncode/parse_result.py
@@ -62,8 +62,14 @@ class ParseResult:
                     for t2 in next_accept_terminals:
                         accept_sequences.add(AcceptSequence([final_terminal, t2]))
                     if ignore_terminals is not None:
-                        for t2 in ignore_terminals:
-                            accept_sequences.add(AcceptSequence([final_terminal, t2]))
+                        for tignore in ignore_terminals:
+                            accept_sequences.add(AcceptSequence([final_terminal, tignore]))
+                        
+                        # These 3 length accept sequences are useful in under-approximating 
+                        # `grammar_strict` mode as they help improve the precision of SynCode
+                        for tignore in ignore_terminals:
+                            for t2 in next_accept_terminals:
+                                accept_sequences.add(AcceptSequence([final_terminal, tignore, t]))
                 else:
                     accept_sequences.add(AcceptSequence([t]))
         

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -32,7 +32,35 @@ class TestParserMisc(unittest.TestCase):
         dfa_mask = DFAMaskStore.load_dfa_mask_store(grammar=grammar, tokenizer=tokenizer, use_cache=False, logger=common.EmptyLogger())
         mask = dfa_mask.get_accept_mask(r, get_list=True)
         self.assertNotIn(' (', mask)
+    
+    @staticmethod
+    def essay_grammar():
+        # A Lark grammar for paragraphs in text
+        return """
+        start: paragraph+
+        ?paragraph: sentence+
+        ?sentence: word+ punctuation
+        word: /[a-zA-Z0-9]+/ | COMMA | SINGLE_QUOTE | ESCAPED_DOUBLE_QUOTE
+        punctuation: /[.!?]/
+        COMMA: ","
+        SINGLE_QUOTE: "'"
+        ESCAPED_DOUBLE_QUOTE: "\\\""
+
+        %import common.WS
+        %ignore WS
+    """
+
+    def test_mask_store_misc2(self):
+        grammar = Grammar(TestParserMisc.essay_grammar())
+        model = 'microsoft/Phi-3-mini-128k-instruct'
+        tokenizer = common.load_tokenizer(model)
+        inc_parser = create_parser(grammar)
+        r = inc_parser.get_acceptable_next_terminals("I")
+        dfa_mask = DFAMaskStore.load_dfa_mask_store(grammar=grammar, tokenizer=tokenizer, use_cache=False, logger=common.EmptyLogger())
+        mask = dfa_mask.get_accept_mask(r, get_list=True)
+        self.assertIn(' have', mask)
         
+
     def test_parser_calc(self):
         inc_parser = create_parser(Grammar('calc'))
         partial_code = "113 + 235 + 17"


### PR DESCRIPTION
In some cases, we are underapproximating the next token set, the model may behave weirdly. This is mainly because the grammar-constrained decoding forces the model to generate whitespace " " and the next word separately. The current LLMs are not trained to generate words after whitespace, and the model's quality can degrade. 

Hence, in this PR we improve the precision of this approach by using accept sequences of length 3 in certain cases. Mainly, when %ignore tokens such as whitespace are present, this would enable SynCode to have a further lookahead. 

Consider a case, input = "I" and the model's next choice is to choose " have" as the next token. SynCode with single lookahead and underapproximating `grammar_strict` mode, would force the model to generate " ". Typically, during the model's actual training, the model is not trained on inputs ending with whitespace. Thus, in the next step, when input="I ", the model's behavior seems to be poorer. 

To fix this, in this PR we allow a longer lookahead accept sequences in some cases.

