### PR TITLE
Remove python time based logging

### DIFF
--- a/syncode/common.py
+++ b/syncode/common.py
@@ -62,21 +62,17 @@ class Logger:
         if task_id is not None:
             prefix = f"task_{task_id}_mode_{mode}_samples_{num_samples_per_task}_parser_{parser}_eval.log"
             log_file = out_dir + 'logs/tasks/' + prefix
-            log_time_file = out_dir + 'logs/tasks/' + 'time_' + prefix
             log_eval_file = out_dir + 'logs/tasks/' + 'eval_' + prefix
             os.makedirs(out_dir + 'logs/tasks/', exist_ok=True)
         else:
             prefix = f"mode_{mode}_samples_{num_samples_per_task}_parser_{parser}_eval.log"
             log_file = out_dir + 'logs/' + prefix
-            log_time_file = out_dir + 'logs/' + 'time_' + prefix
             log_eval_file = out_dir + 'logs/' + 'eval_' + prefix
             os.makedirs(out_dir + 'logs/', exist_ok=True)
         
         if self.log_level >= 1:
             self.log_file = log_file
             self.file = open(log_file, 'w')
-            self.log_time_file = log_time_file
-            self.time_file = open(log_time_file, 'w')
         self.log_eval_file = log_eval_file
         self.eval_file = open(log_eval_file, 'w')
 
@@ -96,11 +92,6 @@ class Logger:
             # Log error in red color
             self.file.write(f"\n\n[ERROR]\n{msg}\n")
             self.file.flush()
-
-    def log_time(self, msg):
-        if self.log_level >= 2:
-            self.time_file.write(msg + '\n')
-            self.time_file.flush()
     
     def log_eval(self, msg):
         if self.log_level >= 0:
@@ -118,14 +109,12 @@ class Logger:
     def close(self):
         if self.log_level >= 1:
             self.file.close()
-            self.time_file.close()
         self.eval_file.close()
         self.is_closed = True
     
     def open(self):
         if self.log_level >= 1:
             self.file = open(self.log_file, 'w')
-            self.time_file = open(self.log_time_file, 'w')
         self.eval_file = open(self.log_eval_file, 'w')
 
 class EmptyLogger(Logger):
@@ -135,9 +124,7 @@ class EmptyLogger(Logger):
     def __init__(self):
         pass
     def log(self, msg):
-        pass  
-    def log_time(self, msg):
-        pass   
+        pass    
     def log_code(self, msg, code):
         pass
     def log_eval(self, msg):

--- a/syncode/evaluation/code_eval.py
+++ b/syncode/evaluation/code_eval.py
@@ -29,7 +29,6 @@ class CodeEval:
                 outputs.append(CodeEval.run_eval_for_task(syncode, num_samples_per_task, format_tabs, problems, samples, pbar, task_id))
             write_jsonl(out_path, samples)
             avg_time = (time.time() - time1) / len(problems)
-            syncode.logger.log_time(f"Averge time taken for each task: {avg_time:.2f}s")
             functional_result = check_coorectness(out_path, logger=syncode.logger)
             syncode.logger.log(f"Functional result: {functional_result}")
 

--- a/syncode/evaluation/json_eval.py
+++ b/syncode/evaluation/json_eval.py
@@ -1,4 +1,3 @@
-import time
 from tqdm import tqdm
 from typing import Optional
 from mxeval.data import write_jsonl
@@ -30,15 +29,12 @@ class JSONEval:
         pbar = tqdm(total=len(problems) * syncode.num_samples)
         results = defaultdict(list)
         
-        time1 = time.time()
-        for task_id, problem in enumerate(problems):
+        for task_id, problem in enumerate(problems[:10]):
             output = JSONEval.run_eval_for_task(syncode, syncode.num_samples, problem, samples, pbar, task_id)
             if debug_task_id is not None:
                 return output
             outputs.append(outputs) 
 
-        avg_time = (time.time() - time1) / len(problems)
-        syncode.logger.log_time(f"Averge time taken for each task: {avg_time:.2f}s")
         
         schema_result = validate_json_data(syncode, samples, results)
 

--- a/syncode/evaluation/math_eval.py
+++ b/syncode/evaluation/math_eval.py
@@ -51,7 +51,6 @@ class MathEval:
 
         # Log result and time
         avg_time = (time.time() - time1) / len(problems)
-        syncode.logger.log_time(f"Averge time taken for each task: {avg_time:.2f}s")
         syncode.logger.log(f"Result: {pass_at_k}")
         print(f"Result: {pass_at_k}")
         syncode.logger.close()

--- a/syncode/language_model.py
+++ b/syncode/language_model.py
@@ -78,7 +78,7 @@ class HuggingFaceModel:
         inputs = self.tokenizer(input_batch, return_tensors="pt").to(self.model.device)
         input_ids_cutoff = inputs.input_ids.size(dim=1)
         
-        start_time = time.time()
+        # Get the generation config
         gen_config = GenerationConfig.from_model_config(self.model.config)
         gen_config.update(**self.gen_args)
 
@@ -127,9 +127,6 @@ class HuggingFaceModel:
                 completion = raw_completion
 
             batch_completions.append(completion)
-
-        if self.grammar_decoder is not None:
-            self.logger.log_time(f"Time taken for generation: {time.time() - start_time:.2f}s")
         
         self.logger.log(f"Completion: {batch_completions}")
         return batch_completions

--- a/syncode/parsers/go_parser.py
+++ b/syncode/parsers/go_parser.py
@@ -26,7 +26,6 @@ class GoIncrementalParser(IncrementalParser):
         self.prev_lexer_tokens = lexer_tokens  # Set the previous lexer tokens
 
         # Parse the tokens
-        parsing_start_time = time.time()
         self.time_accepts = 0
         parse_incomplete = False
         
@@ -51,10 +50,7 @@ class GoIncrementalParser(IncrementalParser):
         except lark.exceptions.UnexpectedToken as e:
             self._handle_parsing_error(lexer_tokens, token)
             parse_incomplete = True
-        
-        self.logger.log_time(f'Time taken for parsing:{time.time() - parsing_start_time}')
-        self.logger.log_time(f'Time taken for computing accepts:{self.time_accepts}')
-        
+                
         # Compute current terminal string
         remainder_state, current_term_str, final_terminal = self._get_remainder(partial_code, parse_incomplete=parse_incomplete)
         

--- a/syncode/parsers/python_parser.py
+++ b/syncode/parsers/python_parser.py
@@ -1,4 +1,4 @@
-import copy, time, regex
+import copy, regex
 from typing import Iterator
 import syncode.larkm as lark
 import syncode.common as common
@@ -44,7 +44,6 @@ class PythonIncrementalParser(IncrementalParser):
         next_ac_indents = None
 
         # Parse the tokens
-        parsing_start_time = time.time()
         self.time_accepts = 0
         
         try:
@@ -77,9 +76,6 @@ class PythonIncrementalParser(IncrementalParser):
                 )
         except lark.exceptions.UnexpectedToken as e:
             self._handle_parsing_error(lexer_tokens, token)
-
-        self.logger.log_time(f'Time taken for parsing:{time.time() - parsing_start_time}')
-        self.logger.log_time(f'Time taken for computing accepts:{self.time_accepts}')
 
         remainder_state, final_terminal = None, None
         # Compute current terminal string
@@ -137,7 +133,6 @@ class PythonIncrementalParser(IncrementalParser):
         indenter: PythonIndenter = self.base_parser.lexer_conf.postlex
 
         # Reset the indentation level
-        lexing_start_time = time.time()
         indenter.indent_level, indenter.paren_level = [0], 0
 
         try:
@@ -163,7 +158,6 @@ class PythonIncrementalParser(IncrementalParser):
         except EOFError as e:
             pass
 
-        self.logger.log_time(f'Time taken for lexing:{time.time() - lexing_start_time}')
         return lexer_tokens
 
 


### PR DESCRIPTION
Since we have somewhat reasonable profiling with `cprof` (Except for `CUDA` synchronization issues), removing the hardcoded logging of time from the code.  