### PR TITLE
Fix JSON evaluation for gemma

### DIFF
--- a/syncode/dataset.py
+++ b/syncode/dataset.py
@@ -50,6 +50,8 @@ class Dataset:
             ds = load_dataset("NousResearch/json-mode-eval", split = "train")
             self.problems = []
             for problem in ds:
+                prompt = [{'content': problem['prompt'][0]['content'] + problem['prompt'][1]['content'], 'role': 'user'}]
+                problem['prompt'] = prompt
                 self.problems.append({**problem, 'prompt': problem['prompt'], 'ground_truth': problem['completion'], 'schema': problem['schema']})
         elif dataset == "folio":
             self.dataset_name = "folio"

--- a/syncode/evaluation/json_eval.py
+++ b/syncode/evaluation/json_eval.py
@@ -29,13 +29,12 @@ class JSONEval:
         pbar = tqdm(total=len(problems) * syncode.num_samples)
         results = defaultdict(list)
         
-        for task_id, problem in enumerate(problems[:10]):
+        for task_id, problem in enumerate(problems):
             output = JSONEval.run_eval_for_task(syncode, syncode.num_samples, problem, samples, pbar, task_id)
             if debug_task_id is not None:
                 return output
             outputs.append(outputs) 
 
-        
         schema_result = validate_json_data(syncode, samples, results)
 
         # exact match evaluation doesn't make sense


### PR DESCRIPTION
JSON evaluation from `nousResearch/json-mode-eval` has a `system` component in the prompt. This is not supported by many recent models like `gemma-2b-it`. This PR is modifying the evaluation in the prompt to fit all the instructions in the `user` part of the message.