### PR TITLE
Decouple infer and evaluation

### DIFF
--- a/notebooks/eval_json.ipynb
+++ b/notebooks/eval_json.ipynb
@@ -1,0 +1,86 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/shubham/anaconda3/envs/codex/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n",
+      "Loading checkpoint shards: 100%|██████████| 2/2 [00:00<00:00, 11.83it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Running Gemma-2-2b-it on JSON evaluation from nousResearch/json-mode-eval\n",
+    "import sys, os\n",
+    "sys.path.append(os.getcwd() + '/../')\n",
+    "from syncode import Syncode\n",
+    "\n",
+    "syn_llm = Syncode(\n",
+    "    mode=\"grammar_mask\",\n",
+    "    model=\"google/gemma-2-2b-it\",\n",
+    "    grammar=\"json\",\n",
+    "    max_new_tokens=400,\n",
+    "    parser=\"lr\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [07:50<00:00,  4.71s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Result: {'pass@1': 0.99}\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = syn_llm.evaluate(dataset=\"json_eval\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "codex",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/example_date.ipynb
+++ b/notebooks/example_date.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 1,
    "id": "ffd1e5da",
    "metadata": {},
    "outputs": [
@@ -10,17 +10,25 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]"
+      "/home/shubham/anaconda3/envs/codex/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n",
+      "Loading checkpoint shards: 100%|██████████| 2/2 [00:00<00:00,  3.61it/s]\n",
+      "Loading checkpoint shards: 100%|██████████| 2/2 [00:00<00:00,  3.69it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating DFA mask store for CodeGenTokenizerFast and custom, may take more than 10 minutes. Caching at /home/shubham/syncode/cache/mask_stores/CodeGenTokenizerFast/grammar_strict_1140931734_50257.pkl.\n",
+      "Ignore whitespace tokens is False\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Loading checkpoint shards: 100%|██████████| 2/2 [00:00<00:00,  4.00it/s]\n",
-      "Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.\n",
-      "Loading checkpoint shards: 100%|██████████| 2/2 [00:00<00:00,  4.08it/s]\n",
-      "Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.\n"
+      "100%|██████████| 96/96 [00:24<00:00,  3.89it/s]\n"
      ]
     }
    ],
@@ -45,10 +53,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 2,
    "id": "f3f9f3b8",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "We detected that you are passing `past_key_values` as a tuple and this is deprecated and will be removed in v4.43. Please use an appropriate `Cache` class (https://huggingface.co/docs/transformers/v4.41.3/en/internal/generation_utils#transformers.Cache)\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -73,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 3,
    "id": "4bf95c2b",
    "metadata": {},
    "outputs": [
@@ -101,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 4,
    "id": "3ad2158b",
    "metadata": {},
    "outputs": [

--- a/syncode/common.py
+++ b/syncode/common.py
@@ -1,11 +1,6 @@
 import os
-from transformers import (
-    LlamaTokenizer,
-    LlamaForCausalLM,
-    AutoTokenizer,
-    AutoModelForCausalLM,
-)
 import torch
+from transformers import AutoTokenizer, AutoModelForCausalLM
 
 # Remove this in future and add instruction to set the HF_CACHE env variable
 RESULTS_DIR = os.environ['RESULTS_DIR'] if 'RESULTS_DIR' in os.environ else 'results/'
@@ -51,6 +46,12 @@ def load_tokenizer(model_name):
         else:
             tokenizer = AutoTokenizer.from_pretrained(model_name, cache_dir=HF_CACHE, token=HF_ACCESS_TOKEN, trust_remote_code=True)
         return tokenizer
+
+def get_output_path(model_name, grammar, dataset, num_samples, mode):
+        out_dir = f"results/{model_name}/{grammar}/{dataset}/"
+        out_path = out_dir + 'samples_' + str(num_samples) + '_mode_' + str(mode) + "_eval.jsonl"
+        os.makedirs(out_dir, exist_ok=True)
+        return out_dir,out_path
 
 class Logger:
     """
@@ -135,4 +136,7 @@ class EmptyLogger(Logger):
         pass
     def close(self):
         pass
-
+    def is_closed(self):
+        return False
+    def open(self):
+        pass

--- a/syncode/evaluation/fol_eval.py
+++ b/syncode/evaluation/fol_eval.py
@@ -3,6 +3,7 @@ Adapted from https://github.com/teacherpeterpan/Logic-LLM. Use Prover9 to solve 
 """
 import random
 import re
+from typing import Optional
 from mxeval.data import write_jsonl
 from tqdm import tqdm
 import signal
@@ -77,7 +78,7 @@ Question:
 
 class FOLEval:
     @staticmethod
-    def run_eval(syncode, debug_task_id=None):
+    def run_eval(syncode, out_path: Optional[str]=None, debug_task_id=None):
         problems = syncode.dataset.problems[:100]
         if debug_task_id is not None:
             problems = [problems[debug_task_id]]
@@ -152,8 +153,9 @@ class FOLEval:
             count_syn_error += (not is_parsed)
             samples += [res]
             pbar.update(syncode.num_samples)
-
-        write_jsonl(syncode.out_path, samples)
+        
+        if out_path is not None: write_jsonl(out_path, samples)
+        
         print(f"Pass rate: {count_pass}/{len(problems)}")
         print(f"Compilation error rate: {count_compile_error}/{len(problems)}")
         print(f"Execution error rate: {count_exec_error}/{len(problems)}")

--- a/syncode/evaluation/sql_eval.py
+++ b/syncode/evaluation/sql_eval.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from tqdm import tqdm
 from mxeval.data import write_jsonl
 
@@ -7,13 +8,13 @@ class SQLEval:
     Run evaluation on SQL dataset
     """
     @staticmethod
-    def run_eval(syncode):
+    def run_eval(syncode, out_path: Optional[str]):
         problems = syncode.dataset.problems[:100]
         samples = []
         pbar = tqdm(total=len(problems) * syncode.num_samples)
         results = {}
         assert syncode.num_samples == 1, "SQL evaluation only supports num_samples=1"
-        predict_file = syncode.out_path
+        predict_file = out_path
 
         if syncode.grammar_decoder is not None:
             syncode.grammar_decoder.parse_output_only = True # Do not parse input+output
@@ -43,4 +44,5 @@ class SQLEval:
         databses = "syncode/utils/sql_spider_eval/databases"
         scores, error_types = evaluate(predict_file, gold_file, databses, etype="all", table=tables, result_jsonl=samples)
         print(f"Scores: {scores['all']}\n Error types: {error_types}")
-        write_jsonl(syncode.out_path, samples)
+        
+        if out_path is not None: write_jsonl(out_path, samples)

--- a/tests/test_language_model.py
+++ b/tests/test_language_model.py
@@ -60,7 +60,7 @@ class TestHuggingFaceModel(unittest.TestCase):
         model = TestModel()
         tokenizer = TestTokenizer()
         logger = common.EmptyLogger()
-        lm = HuggingFaceModel(model, Grammar('calc'), logger, tokenizer, mode='original', max_new_tokens=15, device='cpu')
+        lm = HuggingFaceModel(model, Grammar('calc'), tokenizer, mode='original', max_new_tokens=15, device='cpu')
         prompt = "113 + 235 + 17"
         output = lm.generate_batch_completion_grammar(prompt, 1)
         self.assertEqual(len(output[0]), 15, "The output length does not match the expected value.")
@@ -70,7 +70,7 @@ class TestHuggingFaceModel(unittest.TestCase):
         model = TestModel()
         tokenizer = TestTokenizer()
         logger = common.EmptyLogger()
-        lm = HuggingFaceModel(model, Grammar('calc'), logger, tokenizer, mode='original', max_new_tokens=15, device='cpu')
+        lm = HuggingFaceModel(model, Grammar('calc'), tokenizer, mode='original', max_new_tokens=15, device='cpu')
         prompt = "113 + 235 + 17"
         output = lm.generate_batch_completion_grammar(prompt, 2)
         self.assertEqual(len(output[0]), 15, "The output length does not match the expected value.")

--- a/tests/test_syncode.py
+++ b/tests/test_syncode.py
@@ -1,9 +1,6 @@
 import unittest
-import sys
-import os
-import re
+import sys, os, re
 sys.path.append(os.path.dirname(os.path.realpath(__file__)) + '/../')
-import syncode.common as common
 from syncode.infer import Syncode
 from mxeval.data import get_data
 from syncode.evaluation.mxeval_evaluation import check_correctness_python
@@ -12,7 +9,7 @@ class TestSyncode(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Assuming Syncode and get_data are set up correctly in your environment
-        cls.sg_mask = Syncode(model="test", mode='grammar_mask', device='cpu', do_sample=False, max_new_tokens=200, dataset='humaneval', grammar='python')
+        cls.sg_mask = Syncode(model="test", mode='grammar_mask', device='cpu', do_sample=False, max_new_tokens=200, grammar='python')
         cls.problems = list(get_data('multi-humaneval', 'python').values())
         
         cls.sg_mask_instruct = Syncode(model="test-instruct", mode='grammar_mask', device='cpu', do_sample=False, max_new_tokens=20, grammar=cls.custom_grammar())
@@ -40,12 +37,12 @@ class TestSyncode(unittest.TestCase):
     def test_syntax_mask_humaneval_python(self):
         # Test grammar_mask does not cause functional generated code to fail
         for i in [7, 12, 28]:
-            result = check_correctness_python(self.problems[i], self.sg_mask.infer(task_id=i)[0], timeout=10.0)['result']
+            result = check_correctness_python(self.problems[i], self.sg_mask.evaluate(dataset='humaneval', task_id=i)[0], timeout=10.0)['result']
             self.assertEqual(result, 'passed', f"SynCode Causes Functional Generated Code to Fail for HumanEval/{i}")
         
         # Test grammar_mask eliminates syntax errors in generated code
         for i in [25, 81, 84, 105, 107]:
-            output = self.sg_mask.infer(task_id=i)[0]
+            output = self.sg_mask.evaluate(dataset='humaneval', task_id=i)[0]
             error_type = check_correctness_python(self.problems[i], output, timeout=10.0)['error_type']
             self.assertNotIn('Syntax', error_type, f"Generated Code for HumanEval/{i} has a Syntax Error\n{output}")
 


### PR DESCRIPTION
It is a somewhat big refactoring to clean up the main part of the code in `infer.py`. The function `infer` intended for external API use and function `evaluate` which is useful for evaluating SynCode on standard datasets is decoupled.