### PR TITLE
Update incrementality handling of the parser

### DIFF
--- a/notebooks/tests/beam_search2.ipynb
+++ b/notebooks/tests/beam_search2.ipynb
@@ -1,0 +1,144 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/shubham/anaconda3/envs/codex/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n",
+      "Unrecognized keys in `rope_scaling` for 'rope_type'='linear': {'type'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "from syncode import SyncodeLogitsProcessor, Grammar\n",
+    "from transformers import AutoModelForCausalLM, AutoTokenizer\n",
+    "import lark\n",
+    "\n",
+    "grammar_str = r\"\"\"\n",
+    "start: item (\",\" item)* \n",
+    "\n",
+    "item: \"'\" name \"'\"\n",
+    "    | \"\\\"\" name \"\\\"\"\n",
+    "\n",
+    "name: \"Alice\" \n",
+    "    | \"Bob\" \n",
+    "    | \"Carol\" \n",
+    "    | \"Dave\"\n",
+    "    | \"Eve\"\n",
+    "\"\"\"\n",
+    "\n",
+    "device = \"cuda\"\n",
+    "model_name = \"deepseek-ai/deepseek-coder-1.3b-base\"\n",
+    "model = AutoModelForCausalLM.from_pretrained(model_name, device_map=\"auto\").eval()\n",
+    "tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
+    "\n",
+    "syncode_grammar = Grammar(grammar_str)\n",
+    "parser = lark.Lark(grammar_str)\n",
+    "\n",
+    "prompt = \"A list of male first names:\\n\"\n",
+    "\n",
+    "inputs = tokenizer(prompt, return_tensors=\"pt\").input_ids.to(device)\n",
+    "\n",
+    "constrain = True\n",
+    "\n",
+    "args = {\n",
+    "    \"max_new_tokens\" : 128,\n",
+    "    \"do_sample\" : True,\n",
+    "    \"num_beams\" : 2,\n",
+    "    \"num_return_sequences\" : 2,\n",
+    "    \"pad_token_id\" : tokenizer.eos_token_id,\n",
+    "}\n",
+    "\n",
+    "syncode_logits_processor = SyncodeLogitsProcessor(\n",
+    "    grammar=syncode_grammar, \n",
+    "    tokenizer=tokenizer, \n",
+    "    parse_output_only=True, \n",
+    "    num_samples=args[\"num_beams\"],\n",
+    "    mode=\"grammar_strict\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[\"'Alice'\", '\"Alice\"']\n",
+      ">>> COMPLETION 0\n",
+      "\n",
+      "CAN PARSE\n",
+      "\n",
+      "'Alice'\n",
+      "\n",
+      "[\"'\", 'A', 'lic', 'e', \"'\", '<｜end▁of▁sentence｜>']\n",
+      "\n",
+      ">>> COMPLETION 1\n",
+      "\n",
+      "CAN PARSE\n",
+      "\n",
+      "\"Alice\"\n",
+      "\n",
+      "['\"', 'A', 'lic', 'e', '\"', '<｜end▁of▁sentence｜>']\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "syncode_logits_processor.reset(prompt)\n",
+    "\n",
+    "outputs = model.generate(\n",
+    "    inputs,\n",
+    "    logits_processor=[syncode_logits_processor] if constrain else None,\n",
+    "    **args,\n",
+    ")\n",
+    "\n",
+    "outputs = [o[len(inputs[0]):] for o in outputs]\n",
+    "completions = tokenizer.batch_decode(outputs, skip_special_tokens=True)\n",
+    "completions_tokens = [[tokenizer.decode(tok) for tok in output] for output in outputs]\n",
+    "print(completions)\n",
+    "\n",
+    "\n",
+    "for i, (c, toks) in enumerate(zip(completions, completions_tokens)):\n",
+    "    print(f\">>> COMPLETION {i}\\n\")\n",
+    "    try:\n",
+    "        tree = parser.parse(c)\n",
+    "        print(\"CAN PARSE\\n\")\n",
+    "    except:\n",
+    "        print(\"CANNOT PARSE\\n\") \n",
+    "    print(f\"{c}\\n\")\n",
+    "    print(f\"{toks}\\n\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "codex",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/syncode/infer.py
+++ b/syncode/infer.py
@@ -2,6 +2,7 @@ import os, sys
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import fire
 import syncode.common as common
+import torch
 from syncode.language_model import HuggingFaceModel
 from syncode.grammar_decoder import SyncodeLogitsProcessor
 from typing import Optional, Literal
@@ -14,9 +15,9 @@ from syncode.evaluation.json_eval import JSONEval
 from syncode.evaluation.fol_eval import FOLEval
 
 
-def compile_and_run(model, mode="grammar_strict", quantize=True, device="cuda", num_samples=1, grammar=None, dataset="input", num_few_shot=0, chat_mode=False, dev_mode=False, log_level=1, new_mask_store=False, parser="lalr", task_id=None, **kwargs):
+def compile_and_run(model, mode="grammar_strict", quantize=True, device="cuda", num_samples=1, grammar=None, dataset="input", num_few_shot=0, chat_mode=False, dev_mode=False, log_level=1, new_mask_store=False, parser="lalr", task_id=None, seed=None, **kwargs):
 
-    syncode = Syncode(model, mode=mode, quantize=quantize, device=device, num_samples=num_samples, grammar=grammar, chat_mode=chat_mode, dev_mode=dev_mode, log_level=log_level, new_mask_store=new_mask_store, parser=parser, **kwargs)
+    syncode = Syncode(model, mode=mode, quantize=quantize, device=device, num_samples=num_samples, grammar=grammar, chat_mode=chat_mode, dev_mode=dev_mode, log_level=log_level, new_mask_store=new_mask_store, parser=parser, seed=seed, **kwargs)
     
     if dataset == "input":
         syncode.infer()
@@ -71,6 +72,7 @@ class Syncode:
         log_level: int = 1,
         new_mask_store: bool = False,
         parser: Literal["lr", "lalr"] = "lalr",
+        seed: Optional[int] = None,
         **kwargs
     ):  
         # Check inputs
@@ -89,6 +91,10 @@ class Syncode:
         self.parser = parser
         self.chat_mode = chat_mode
         self.log_level = log_level
+
+        # Set seed
+        if seed is not None:
+            torch.manual_seed(seed)
 
         if self.chat_mode:
             self.parse_output_only = True

--- a/syncode/parsers/go_parser.py
+++ b/syncode/parsers/go_parser.py
@@ -23,8 +23,6 @@ class GoIncrementalParser(IncrementalParser):
         # Restore the previous state of the parser
         self._restore_recent_parser_state(lexer_tokens)
         
-        self.prev_lexer_tokens = lexer_tokens  # Set the previous lexer tokens
-
         # Parse the tokens
         self.time_accepts = 0
         parse_incomplete = False
@@ -44,6 +42,7 @@ class GoIncrementalParser(IncrementalParser):
                 # Store the current state of the parser
                 self._store_parser_state(
                     self.cur_pos-1, 
+                    lexer_tokens,
                     interactive.parser_state.copy(), 
                     self._accepts(interactive)
                     )

--- a/syncode/parsers/python_parser.py
+++ b/syncode/parsers/python_parser.py
@@ -40,7 +40,6 @@ class PythonIncrementalParser(IncrementalParser):
         # Restore the previous state of the parser
         self._restore_recent_parser_state(lexer_tokens)
         
-        self.prev_lexer_tokens = lexer_tokens  # Set the previous lexer tokens for retrieving the state of the parser in next iterations
         next_ac_indents = None
 
         # Parse the tokens
@@ -69,7 +68,8 @@ class PythonIncrementalParser(IncrementalParser):
 
                 # Store the current state of the parser
                 self._store_parser_state(
-                    self.cur_pos-1, 
+                    self.cur_pos-1,
+                    lexer_tokens, 
                     interactive.parser_state.copy(), 
                     self._accepts(interactive),
                     indent_levels=copy.copy(self.indent_level)


### PR DESCRIPTION
Instead of restoring the parser state from the previous version of lexer tokens, we use the hash of the lexer tokens to cache the parser state. 