### PR TITLE
Add grammar ambiguity error check

### DIFF
--- a/syncode/parsers/__init__.py
+++ b/syncode/parsers/__init__.py
@@ -20,12 +20,21 @@ def create_parser(grammar: Grammar, parser='lalr', **kwargs) -> incremental_pars
             indenter = PythonIndenter()
 
         base_parser = create_base_parser(grammar, parser, indenter, cache_filename)
-
+        check_grammar_errors(base_parser)
+                         
         if grammar.name == 'python':
             return PythonIncrementalParser(base_parser, indenter, **kwargs)
         elif grammar.name == 'go':
             return GoIncrementalParser(base_parser, **kwargs)
         return incremental_parser.IncrementalParser(base_parser, **kwargs)
+
+def check_grammar_errors(base_parser):
+    for t1 in base_parser.terminals:
+         for t2 in base_parser.terminals:
+              if t1.pattern.type == 'str' and t2.pattern.type == 'str' and t1 != t2:
+                       # If either of the strings is a substring of the other, then we raise an error
+                    if t1.pattern.value in t2.pattern.value or t2.pattern.value in t1.pattern.value:
+                        raise ValueError(f"Terminals {t1.name} and {t2.name} have overlapping patterns: {t1.pattern.value} and {t2.pattern.value}")
 
 def create_base_parser(grammar, parser='lalr', indenter=None, cache_filename=None):
     base_parser = Lark( # This is the standard Lark parser

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -70,6 +70,19 @@ class TestParserMisc(unittest.TestCase):
         mask = dfa_mask.get_accept_mask(r, get_list=True)
         self.assertIn(' I', mask)
 
+    def test_lexer_error(self):
+        grammar = """ 
+                start: name1 | name2
+                name1: "Ali"
+                name2: "Aliana"
+        """
+        try:
+            _ = create_parser(Grammar(grammar))
+            is_error = False
+        except ValueError as e:
+            is_error = True
+        self.assertTrue(is_error)
+
     def test_parser_calc(self):
         inc_parser = create_parser(Grammar('calc'))
         partial_code = "113 + 235 + 17"
@@ -112,3 +125,4 @@ Jokes(rina) ⊕ Unaware(rina) ::: Rina is either a person who jokes about being 
         partial_code = f"""Predicates:\nPer"""
         r = inc_parser.get_acceptable_next_terminals(partial_code)
         print(r)
+    


### PR DESCRIPTION
If one of the terminal definition strings is a subset of another, this is given as an error statically.