### PR TITLE
Add a debug flag

### DIFF
--- a/notebooks/tests/debug_grammar.ipynb
+++ b/notebooks/tests/debug_grammar.ipynb
@@ -1,0 +1,88 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/shubham/anaconda3/envs/codex/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n",
+      "Loading checkpoint shards: 100%|██████████| 2/2 [00:00<00:00, 11.27it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from syncode.infer import Syncode\n",
+    "\n",
+    "# Load the unconstrained original model\n",
+    "model_name = \"microsoft/Phi-3-mini-4k-instruct\"\n",
+    "\n",
+    "grammar = r\"\"\" \n",
+    "                start: instruction\n",
+    "                instruction: \"Press the \" button \" button\"\n",
+    "                button: \"power\" | \"volume up\" | \"volume down\" | \"home\" | \"back\" | \"recent apps\" | \"menu\" | \"search\"\n",
+    "        \"\"\"\n",
+    "\n",
+    "syn_llm = Syncode(model=model_name, grammar=grammar)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------------------------------------------\n",
+      "Parsed terminals:\n",
+      "(type: 'Press\\\\ the\\\\ ' | value: 'Press the ')\n",
+      "(type: 'back' | value: 'back')\n",
+      "(type: '\\\\ button' | value: ' button')\n",
+      "--------------------------------------------------\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['Press the back button']"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "prompt = \"How do I go back?\"\n",
+    "syn_llm.infer(prompt, debug=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "codex",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/syncode/grammar_decoder.py
+++ b/syncode/grammar_decoder.py
@@ -205,3 +205,14 @@ class SyncodeLogitsProcessor(LogitsProcessor):
         self.logger.log(f"Greedy grammar-based token: {repr(greedy_grammar_token)}")
         self._log_current_status(partial_code, r)
     
+    def print_debug(self):
+        print('-'*50)
+        print('Parsed terminals:')
+
+        name_to_pattern = {}
+        for term in self.inc_parser.base_parser.terminals:
+            name_to_pattern[term.name] = term.pattern
+
+        for token in self.inc_parser.parsed_lexer_tokens:
+            print(f"(type: {name_to_pattern[token.type]} | value: '{token.value}')")
+        print('-'*50)

--- a/syncode/parsers/grammars/README.md
+++ b/syncode/parsers/grammars/README.md
@@ -19,6 +19,29 @@ LR(1) is more powerful in terms of representing certain syntax, however common f
 In most cases, it should be possible to fix these errors by rewriting some of the grammar rules.
 However, in some rare cases it is possible that it is impossible to represent the grammar as LR(1)
 
+### Debugging Grammars
+
+SynCode provides a flag `--debug` to help debug grammars. This flag will print out the parsed terminals and their corresponding values in generation.
+(Refer to [this](../../../notebooks/tests/debug_grammar.ipynb) notebook for code example)
+
+For example, consider the following grammar:
+```ebnf
+start: "foo" "(" ident ")" ";"
+ident: [a-z]+
+```
+
+Given the output `foo(abc);`, the debug flag will print:
+```
+--------------------------------------------------
+Parsed terminals:
+(type: 'FOO', value: 'foo')
+(type: 'LPAR', value: '(')
+(type: 'IDENT', value: 'abc')
+(type: 'RPAR', value: ')')
+(type: 'SEMI', value: ';')
+--------------------------------------------------
+```
+
 ### Lexer Ambiguity 
 When defining a grammar, be cautious of lexer ambiguities that arise when one terminal is a substring of another.
 In some cases, these ambiguities can lead to unexpected behavior in the parser. 


### PR DESCRIPTION

SynCode provides a flag `--debug` to help debug grammars. This flag will print out the parsed terminals and their corresponding values in generation.
(Refer to [this](../../../notebooks/tests/debug_grammar.ipynb) notebook for code example)

For example, consider the following grammar:
```ebnf
start: "foo" "(" ident ")" ";"
ident: [a-z]+
```

Given the output `foo(abc);`, the debug flag will print:
```
--------------------------------------------------
Parsed terminals:
(type: 'FOO', value: 'foo')
(type: 'LPAR', value: '(')
(type: 'IDENT', value: 'abc')
(type: 'RPAR', value: ')')
(type: 'SEMI', value: ';')
--------------------------------------------------
```
