### PR TITLE
For instruct mode input can be list of user and system message

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,20 @@ print(f"SynCode output:\n{output}")
 Check more examples of using Python, Go, and other grammars in <a href="#-example-usage">Notebooks</a> and a quick example at 
 &nbsp; [<img align="center" src="https://colab.research.google.com/assets/colab-badge.svg" />](https://colab.research.google.com/drive/1rYm8iehx_qYdtgWmqLkmhIjizhUVTb9E?usp=sharing)
 
+#### Instuct-tuned Models
+SynCode can also be used with Instruct-tuned models. For example, the following code snippet shows how to use SynCode with the Instruct-tuned LLM model.
+
+``` python
+messages = [
+    {"role": "system", "content": "You are a chatbot who always returns a JSON object."},
+    {"role": "user", "content": "can you give me a JSON object describing University of Illinois at Urbana-Champaign?"},
+]
+
+out = syn_llm.infer(messages)
+```
+
+ See the [notebook](./notebooks/example_instruct_model.ipynb) for example.
+
 ### Environment Variables
 Optionally, you can set the directories for cache by exporting the following environment variables. Add the following lines to your .bashrc or .zshrc file:
 ```
@@ -179,8 +193,6 @@ export HF_ACCESS_TOKEN="your_huggingface_api_key"
 - `dataset` (str, optional): Dataset. Defaults to "input". "input" indicates that the user can provide input via CLI or by passing in a prompt as a string. 
    
 - `num_few_shot` (int, optional): Number of examples for few-shot prompting. Defaults to 0.
-    
-- `chat_mode` (bool, optional): True if using a Chat/Instruct LLM. False otherwise. Defaults to False. 
   
 - `dev_mode` (bool, optional): Development mode where we do not fail silently with parser errors. Defaults to False.
   
@@ -217,7 +229,6 @@ python3 syncode/infer.py
     --dataset [mbxp, humaneval, mathqa-x, input]
     --few_shot [True, False]
     --num_fs_examples [num_fs_examples]
-    --chat_mode [True, False]
     --dev_mode [True, False]
     --log_level [0, 1, 2]
     --new_mask_store [True, False]

--- a/notebooks/example.ipynb
+++ b/notebooks/example.ipynb
@@ -79,10 +79,10 @@
     "model_name = \"microsoft/phi-2\"\n",
     "\n",
     "# Load the unconstrained original model\n",
-    "llm = Syncode(model = model_name, mode='original', max_new_tokens=20, chat_mode=True)\n",
+    "llm = Syncode(model = model_name, mode='original', max_new_tokens=20)\n",
     "\n",
     "# Load the Syncode augmented model\n",
-    "syn_llm = Syncode(model = model_name, mode='grammar_mask', grammar=grammar, chat_mode=True)"
+    "syn_llm = Syncode(model = model_name, mode='grammar_mask', grammar=grammar)"
    ]
   },
   {

--- a/notebooks/example_instruct_model.ipynb
+++ b/notebooks/example_instruct_model.ipynb
@@ -1,0 +1,99 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/shubham/anaconda3/envs/codex/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n",
+      "Loading checkpoint shards: 100%|██████████| 4/4 [00:00<00:00, 12.69it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from syncode import Syncode\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "\n",
+    "model_name = \"meta-llama/Meta-Llama-3-8B-Instruct\"\n",
+    "\n",
+    "# Load the Syncode augmented model\n",
+    "syn_llm = Syncode(model=model_name, grammar='json', max_new_tokens=400)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
+      "Setting `pad_token_id` to `eos_token_id`:128009 for open-end generation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{ \"name\": \"University of Illinois at Urbana-Champaign\", \n",
+      "\"location\": \"Champaign, Illinois, USA\", \n",
+      "\"established\": 1867, \n",
+      "\"type\": \"Public research university\", \n",
+      "\"enrollment\": 50000, \n",
+      "\"campus\": \"Urban\", \n",
+      "\"mascot\": \"Chief Illiniwek\", \n",
+      "\"athletic_conference\": \"Big Ten Conference\", \n",
+      "\"notable_alumni\": [\"Ray Kroc\", \"Lee DeForest\", \"Napoleon Hill\", \"John Bardeen\", \"Roger Ebert\"], \n",
+      "\"reputation\": \"Highly ranked in the US News & World Report's Best Colleges\", \n",
+      "\"programs\": [\"Engineering\", \"Business\", \"Agriculture\", \"Computer Science\", \"Education\"], \n",
+      "\"research_areas\": [\"Materials Science\", \"Biotechnology\", \"Energy\", \"Aerospace Engineering\", \"Computer Science\"], \n",
+      "\"campus_size\": \"1,783 acres\", \n",
+      "\"student_to_faculty_ratio\": \"18:1\", \n",
+      "\"acceptance_rate\": \"64.4%\", \n",
+      "\"tuition\": \"$15,622 (in-state), $29,444 (out-of-state)\" } \n",
+      "\n",
+      " \n"
+     ]
+    }
+   ],
+   "source": [
+    "messages = [\n",
+    "    {\"role\": \"system\", \"content\": \"You are a chatbot who always returns a JSON object.\"},\n",
+    "    {\"role\": \"user\", \"content\": \"can you give me a JSON object describing University of Illinois at Urbana-Champaign?\"},\n",
+    "]\n",
+    "\n",
+    "out = syn_llm.infer(messages)\n",
+    "print(out[0])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "codex",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/syncode/evaluation/code_eval.py
+++ b/syncode/evaluation/code_eval.py
@@ -68,7 +68,7 @@ class CodeEval:
         else:
             prompt = problems[task_id]["prompt"]
 
-        batch_completions = syncode.model.generate_batch_completion_grammar(prompt, num_samples_per_task, stop_words=stop_words, return_token_ids=True)
+        batch_completions = syncode.model.generate_grammar_constrained_completion(prompt, num_samples_per_task, stop_words=stop_words, return_token_ids=True)
         batch_size = len(batch_completions)
         all_completions = []
 

--- a/tests/test_language_model.py
+++ b/tests/test_language_model.py
@@ -62,7 +62,7 @@ class TestHuggingFaceModel(unittest.TestCase):
         logger = common.EmptyLogger()
         lm = HuggingFaceModel(model, Grammar('calc'), tokenizer, mode='original', max_new_tokens=15, device='cpu')
         prompt = "113 + 235 + 17"
-        output = lm.generate_batch_completion_grammar(prompt, 1)
+        output = lm.generate_grammar_constrained_completion(prompt, 1)
         self.assertEqual(len(output[0]), 15, "The output length does not match the expected value.")
     
     def test_generate_batch_completion_grammar2(self):
@@ -72,7 +72,7 @@ class TestHuggingFaceModel(unittest.TestCase):
         logger = common.EmptyLogger()
         lm = HuggingFaceModel(model, Grammar('calc'), tokenizer, mode='original', max_new_tokens=15, device='cpu')
         prompt = "113 + 235 + 17"
-        output = lm.generate_batch_completion_grammar(prompt, 2)
+        output = lm.generate_grammar_constrained_completion(prompt, 2)
         self.assertEqual(len(output[0]), 15, "The output length does not match the expected value.")
         self.assertEqual(len(output[1]), 15, "The output length does not match the expected value.")
     


### PR DESCRIPTION
SynCode can also be used with Instruct-tuned models. For example, the following code snippet shows how to use SynCode with the Instruct-tuned LLM model.

``` python
messages = [
    {"role": "system", "content": "You are a chatbot who always returns a JSON object."},
    {"role": "user", "content": "can you give me a JSON object describing University of Illinois at Urbana-Champaign?"},
]

out = syn_llm.infer(messages)
```

 See the [notebook](./notebooks/example_instruct_model.ipynb) for example.