### PR TITLE
Fixes to parser and explicitly print parsing error

### DIFF
--- a/notebooks/tests/builtin_grammar.ipynb
+++ b/notebooks/tests/builtin_grammar.ipynb
@@ -1,0 +1,131 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/shubham/anaconda3/envs/codex/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "from syncode import SyncodeLogitsProcessor\n",
+    "from syncode import Grammar\n",
+    "from transformers import AutoModelForCausalLM, AutoTokenizer\n",
+    "import os\n",
+    "\n",
+    "HF_CACHE = os.environ['HF_CACHE'] if 'HF_CACHE' in os.environ else 'cache/'\n",
+    "HF_ACCESS_TOKEN = os.environ['HF_ACCESS_TOKEN'] if 'HF_ACCESS_TOKEN' in os.environ else None\n",
+    "\n",
+    "device = 'cuda'\n",
+    "model_name = \"meta-llama/Llama-3.2-1B-Instruct\"\n",
+    "# model_name = \"meta-llama/Llama-3.1-8B-Instruct\"\n",
+    "\n",
+    "model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.bfloat16, cache_dir=HF_CACHE, token=HF_ACCESS_TOKEN, trust_remote_code=True).eval().to(device)\n",
+    "tokenizer = AutoTokenizer.from_pretrained(model_name, cache_dir=HF_CACHE, token=HF_ACCESS_TOKEN, trust_remote_code=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[PROMPT] <|begin_of_text|><|start_header_id|>system<|end_header_id|>\n",
+      "\n",
+      "Cutting Knowledge Date: December 2023\n",
+      "Today Date: 26 Jul 2024\n",
+      "\n",
+      "<|eot_id|><|start_header_id|>user<|end_header_id|>\n",
+      "\n",
+      "Write a java function that prints 'hello world' in reverse.<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n",
+      "\n",
+      " \n",
+      "\n",
+      "[OUTPUT] public class HelloWorld {\n",
+      "    public static void main(String[] args) {\n",
+      "        System.out.println(\"Hello World\");\n",
+      "    } \n",
+      "\n",
+      "    public static void printReverse(String str) {\n",
+      "        char[] arr = str.toCharArray();\n",
+      "        int start = 0;\n",
+      "        int end = arr.length - 1;\n",
+      "\n",
+      "        while (start < end) {\n",
+      "            System.out.print(arr[start]);\n",
+      "            System.out.print(arr[end]);\n",
+      "            start++;\n",
+      "            end--;\n",
+      "        } \n",
+      "        System.out.println();\n",
+      "    } \n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# grammar_str = \"python\"\n",
+    "# grammar_str = \"go\"\n",
+    "grammar_str = \"java\"\n",
+    "\n",
+    "grammar = Grammar(grammar_str)\n",
+    "syncode_logits_processor = SyncodeLogitsProcessor(grammar=grammar, tokenizer=tokenizer, parse_output_only=True)\n",
+    "\n",
+    "prompt = f\"Write a {grammar_str} function that prints 'hello world' in reverse.\"\n",
+    "messages = [{\"role\": \"user\", \"content\": prompt}]\n",
+    "prompt = tokenizer.apply_chat_template(\n",
+    "                  messages, tokenize=False, add_generation_prompt=True\n",
+    "            )\n",
+    "print(\"[PROMPT]\", prompt, \"\\n\")\n",
+    "\n",
+    "syncode_logits_processor.reset(prompt)\n",
+    "\n",
+    "inputs = tokenizer(prompt, return_tensors='pt').input_ids.to(device)\n",
+    "\n",
+    "attention_mask = torch.ones_like(inputs)\n",
+    "output = model.generate(\n",
+    "      inputs,\n",
+    "      attention_mask=attention_mask,\n",
+    "      max_length=512, \n",
+    "      num_return_sequences=1, \n",
+    "      pad_token_id=tokenizer.eos_token_id, \n",
+    "      logits_processor=[syncode_logits_processor]\n",
+    "      )\n",
+    "output_str = tokenizer.decode(output[0][len(inputs[0]):], skip_special_tokens=True)\n",
+    "print(\"[OUTPUT]\", output_str)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "codex",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/syncode/parsers/go_parser.py
+++ b/syncode/parsers/go_parser.py
@@ -47,7 +47,7 @@ class GoIncrementalParser(IncrementalParser):
                     self._accepts(interactive)
                     )
         except lark.exceptions.UnexpectedToken as e:
-            self._handle_parsing_error(lexer_tokens, token)
+            self._handle_parsing_error(lexer_tokens, token, e)
             parse_incomplete = True
                 
         # Compute current terminal string

--- a/syncode/parsers/python_parser.py
+++ b/syncode/parsers/python_parser.py
@@ -32,10 +32,10 @@ class PythonIncrementalParser(IncrementalParser):
             tab_len = indent_type.count(' ')
         return tab_len
 
-    def get_acceptable_next_terminals(self, code) -> ParseResult:
+    def get_acceptable_next_terminals(self, partial_code) -> ParseResult:
         # Stores the sequence of tokens that the parser has seen in the order  
         interactive = self.interactive
-        lexer_tokens = self._lex_code(code)
+        lexer_tokens, lexing_incomplete = self._lex_code(partial_code)
 
         # Restore the previous state of the parser
         self._restore_recent_parser_state(lexer_tokens)
@@ -44,6 +44,7 @@ class PythonIncrementalParser(IncrementalParser):
 
         # Parse the tokens
         self.time_accepts = 0
+        parse_incomplete = False
         
         try:
             while self.cur_pos < len(lexer_tokens):
@@ -75,27 +76,17 @@ class PythonIncrementalParser(IncrementalParser):
                     indent_levels=copy.copy(self.indent_level)
                 )
         except lark.exceptions.UnexpectedToken as e:
-            self._handle_parsing_error(lexer_tokens, token)
+            parse_incomplete = True
+            self._handle_parsing_error(lexer_tokens, token, e)
 
         remainder_state, final_terminal = None, None
+        
         # Compute current terminal string
-        if self.lexer_pos < len(code):
-            remainder_state = RemainderState.INCOMPLETE
-            current_term_str = code[self.lexer_pos:]
-
-            current_term_str = current_term_str.lstrip(' ') # Remove space from the beginning
-            if current_term_str == '':
-                remainder_state = RemainderState.COMPLETE
-        else:
-            # Although this is a complete terminal, it may happen that this may be just prefix of some other terminal
-            # e.g., 'de' may seem like a variable name that is complete, but it may be just a prefix of 'def'
-            current_term_str = self.parsed_lexer_tokens[-1].value
-            remainder_state = RemainderState.MAYBE_COMPLETE
-            final_terminal = self.parsed_lexer_tokens[-1].type
+        remainder_state, current_term_str, final_terminal = self._get_remainder(partial_code, lexing_incomplete=lexing_incomplete, parse_incomplete=parse_incomplete)  
 
         next_ac_indents = None
         if remainder_state == RemainderState.MAYBE_COMPLETE or remainder_state == RemainderState.COMPLETE:
-            if self.parsed_lexer_tokens[-1].type == '_NL':
+            if len(self.parsed_lexer_tokens) > 0 and self.parsed_lexer_tokens[-1].type == '_NL':
                 last_indent_str = self.parsed_lexer_tokens[-1].value.split('\n')[-1]
                 last_indent = last_indent_str.count(' ') + last_indent_str.count('\t') * self.tab_len
                 next_ac_indents = [indent-last_indent for indent in self.indent_level if indent >= last_indent]
@@ -110,10 +101,6 @@ class PythonIncrementalParser(IncrementalParser):
                 # '_NL' is always accepted in this case
                 self.cur_ac_terminals.add('_NL')
                 self.next_ac_terminals.add('_NL') 
-
-        else: # Since current terminal is incomplete, next token should add to current terminal
-            self.cur_ac_terminals = self.next_ac_terminals
-            self.next_ac_terminals = set()
 
         return ParseResult.from_accept_terminals(self.cur_ac_terminals, self.next_ac_terminals, current_term_str, remainder_state, next_ac_indents=next_ac_indents, final_terminal=final_terminal, ignore_terminals=self.base_parser.lexer_conf.ignore)
 
@@ -131,6 +118,7 @@ class PythonIncrementalParser(IncrementalParser):
         interactive = self.base_parser.parse_interactive(code)
         lexer_state = interactive.lexer_thread.state
         indenter: PythonIndenter = self.base_parser.lexer_conf.postlex
+        lexing_incomplete = False
 
         # Reset the indentation level
         indenter.indent_level, indenter.paren_level = [0], 0
@@ -154,11 +142,12 @@ class PythonIncrementalParser(IncrementalParser):
                         indenter.paren_level -= 1
                         assert indenter.paren_level >= 0
         except lark.exceptions.UnexpectedCharacters as e: 
+            lexing_incomplete = True
             pass # This may happen when the partial code has an ignore terminal
         except EOFError as e:
             pass
 
-        return lexer_tokens
+        return lexer_tokens, lexing_incomplete
 
 
 class PythonIndenter(Indenter):

--- a/tests/test_grammar_go.py
+++ b/tests/test_grammar_go.py
@@ -7,7 +7,7 @@ from syncode.parsers.grammars.grammar import Grammar
 from syncode.parse_result import AcceptSequence, RemainderState
 
 go_grammar = Grammar('go')
-inc_parser = create_parser(go_grammar)
+inc_parser = create_parser(go_grammar, ignore_whitespace=True)
 
 class TestGoParser(unittest.TestCase):
 

--- a/tests/test_grammar_python.py
+++ b/tests/test_grammar_python.py
@@ -11,7 +11,7 @@ from syncode.parse_result import AcceptSequence, RemainderState
 from syncode.parsers.grammars.grammar import Grammar
 
 python_grammar = Grammar('python')
-inc_parser = create_parser(python_grammar)
+inc_parser = create_parser(python_grammar, ignore_whitespace=True)
 
 class TestPythonParser(unittest.TestCase):
     @unittest.skip("Skipping the correctness comparison test.")
@@ -132,6 +132,7 @@ def foo():
         inc_parser.reset()
         partial_code = 'from typing import List\n\n\ndef separate_paren_groups(paren_string: str) -> List[str]:\n\tpar = []\n\tfor i in par:\n\t\tif i == \'Hello'
         r = inc_parser.get_acceptable_next_terminals(partial_code)
+        print(inc_parser._ignore_whitespace)
         self.assertEqual(r.remainder, "'Hello")
 
     def test_parser10(self):
@@ -313,6 +314,7 @@ def cat():
         inc_parser.reset()
         partial_code = "def make_palindrome(string: str):\n\tfor i i"
         r = inc_parser.get_acceptable_next_terminals(partial_code)
+        print(r)
         assert r.remainder == 'i'
         assert AcceptSequence(['IN']) in r.accept_sequences
         # TODO: FIX THIS TEST. 


### PR DESCRIPTION
This PR includes two main changes:

1) There are some fixes in parsers when the generation starts with empty output in the case of NL to code tasks for general programming languages.

2) The parsing error and switch to unconstrained generation on an error is made more explicit. -- On any parsing error SynCode typically falls back to unconstrained generation (unless `dev_mode` flag is on). In the case of the `grammar_mask` mode, a parsing error can occur when the SynCode generation diverges from the grammar as SynCode does not always guarantee adherence to grammar. 

Test:
```
python3 syncode/infer.py --mode grammar_mask --model meta-llama/Llama-2-7b-hf  --dataset humaneval --grammar python --max_new_tokens 400 --parser lr --parse_output_only False
```
results in pass@1 of ~12%

