### PR TITLE
Compress mask store by only storing viable terminal sequences

### DIFF
--- a/syncode/grammar_decoder.py
+++ b/syncode/grammar_decoder.py
@@ -51,6 +51,9 @@ class SyncodeLogitsProcessor(LogitsProcessor):
         # Ignore whitespace tokens
         self._ignore_whitespace = self._get_ignore_whitespace(self.grammar)
 
+        # Create parser
+        self.inc_parser: IncrementalParser = create_parser(self.grammar, logger=self.logger, parser=parser, ignore_whitespace=self._ignore_whitespace)
+
         # Load dfa mask store
         self.dfa_mask_store = DFAMaskStore.load_dfa_mask_store(
                                     grammar=self.grammar, 
@@ -58,10 +61,8 @@ class SyncodeLogitsProcessor(LogitsProcessor):
                                     use_cache=use_cache, 
                                     logger=self.logger,
                                     mode=mode,
+                                    parse_table=self.inc_parser.base_parser.parser.parser._parse_table,
                                     )
-
-        # Create parser
-        self.inc_parser: IncrementalParser = create_parser(self.grammar, logger=self.logger, parser=parser, ignore_whitespace=self._ignore_whitespace)
 
     
     def _log_current_status(self, partial_code, r: ParseResult):


### PR DESCRIPTION
This change makes the mask store size and computation time roughly 2-3x smaller.  
This PR introduces `_compute_following_terminals_map` in the DFA mask store, a method that determines which terminals can legally follow a given terminal based on the parsing table. It iterates through parser states, identifying shift actions and collecting valid next terminals for each current terminal. 

Test:
```
python3 syncode/infer.py --mode grammar_mask --model meta-llama/Llama-2-7b-hf  --dataset humaneval --grammar python --max_new_tokens 400 --parser lr --parse_output_only False --new_mask_store True
```
results in pass@1 of ~13.41%
Mask store size: Reduces from 1.17G to 389M

```
python3 syncode/infer.py --mode grammar_strict --model google/gemma-2-2b-it --dataset json_eval --grammar json --max_new_tokens 400 --parser lalr  --new_mask_store True
```
results in 98% accuracy
Mask store size: Reduces from 219M to 105M

