### PR TITLE
Do not allow empty strings for JSON keys

### DIFF
--- a/syncode/parsers/grammars/json_grammar.lark
+++ b/syncode/parsers/grammars/json_grammar.lark
@@ -3,7 +3,7 @@
 
 ?value: object
 | array
-| UNESCAPED_STRING
+| EMPTY_STRING
 | NONEMPTY_STRING
 | SIGNED_NUMBER      -> number
 | "true"             -> true
@@ -15,7 +15,7 @@ object : "{" [pair ("," pair)*] "}"
 pair   : NONEMPTY_STRING ":" value
 
 NONEMPTY_STRING: /\"[^"]+\"/
-UNESCAPED_STRING: /\"[^"]*\"/
+EMPTY_STRING: /\"\"/
 
 DIGIT: "0".."9"
 HEXDIGIT: "a".."f"|"A".."F"|DIGIT

--- a/syncode/parsers/grammars/json_grammar.lark
+++ b/syncode/parsers/grammars/json_grammar.lark
@@ -4,6 +4,7 @@
 ?value: object
 | array
 | UNESCAPED_STRING
+| NONEMPTY_STRING
 | SIGNED_NUMBER      -> number
 | "true"             -> true
 | "false"            -> false

--- a/syncode/parsers/grammars/json_grammar.lark
+++ b/syncode/parsers/grammars/json_grammar.lark
@@ -11,8 +11,9 @@
 
 array  : "[" [value ("," value)*] "]"
 object : "{" [pair ("," pair)*] "}"
-pair   : UNESCAPED_STRING ":" value
+pair   : NONEMPTY_STRING ":" value
 
+NONEMPTY_STRING: /\"[^"]+\"/
 UNESCAPED_STRING: /\"[^"]*\"/
 
 DIGIT: "0".."9"


### PR DESCRIPTION
Removed choice of empty string values for keys. It does not make sense for keys to have empty string values even though it is allowed by JSON formatting (Thoughts on this?)

Anecdote: The model started giving an unending output like this { "" : { "" : { "" : ... 

Making this change took this choice away from the model and I think once it starts predicting actual non-empty keys, it boosts the probability for it to predict proper values in the next iterations.