### PR TITLE
Use absolute imports for better disambiguation

### DIFF
--- a/syncode/__init__.py
+++ b/syncode/__init__.py
@@ -1,6 +1,6 @@
 from syncode.infer import Syncode
-from grammar_decoder import SyncodeLogitsProcessor
-from parsers.grammars import Grammar
-import common
+from syncode.grammar_decoder import SyncodeLogitsProcessor
+from syncode.parsers.grammars import Grammar
+import syncode.common as common
 
 common.setup_logging()


### PR DESCRIPTION
Lot of projects contain a "common" (and sometimes "parsers") module which may conflict with syncode's internal modules