### PR TITLE
Add start_value for json_grammar

### DIFF
--- a/syncode/parsers/grammars/json_grammar.lark
+++ b/syncode/parsers/grammars/json_grammar.lark
@@ -1,5 +1,8 @@
 // Adapted from https://github.com/lapp0/outlines
-?start: value
+?start: start_value
+
+?start_value: object
+| array
 
 ?value: object
 | array


### PR DESCRIPTION
The JSON start_values are limited to objects and arrays. Although number, boolean and null strings are also valid JSON, there is no practical use for including them as a start_value